### PR TITLE
add missing 'faoebx5' remote dep (not in CRAN)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,8 @@ Imports:
     faoebx5,
     dplyr,
     data.table
+Remotes:
+    lgsilvaesilva/faoebx5
 Suggests:
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Imports:
     dplyr,
     data.table
 Remotes:
-    lgsilvaesilva/faoebx5
+    bergertom/faoebx5
 Suggests:
     knitr,
     rmarkdown


### PR DESCRIPTION
@bergertom thanks a lot for this package.
Here is a small pull request to improve the installation: The 'faoebx5' is not on CRAN (at least not yet), only in Github. For users that don't have it installed yet, the install of ``fishstatr`` fails. For that a simple add of faoebx5 github repo as ``Remotes`` reference in the DESCRIPTION. For a first installation this will trigger installation of 'faoebx5'.